### PR TITLE
add MCP server badge

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,6 +2,10 @@
 
 Este proyecto implementa un servidor MCP (Model Context Protocol) para interactuar con el sistema de Setups de Chop. Proporciona una interfaz para obtener información de setups a través de una API REST.
 
+<a href="https://glama.ai/mcp/servers/@LucasDelgado/mcp-ts">
+  <img width="380" height="200" src="https://glama.ai/mcp/servers/@LucasDelgado/mcp-ts/badge" alt="Chop TypeScript MCP server" />
+</a>
+
 ## Características
 
 - Implementación del Model Context Protocol (MCP)


### PR DESCRIPTION
This PR adds a badge for the [Chop MCP TypeScript](https://glama.ai/mcp/servers/@LucasDelgado/mcp-ts) server listing in Glama MCP server directory.

<a href="https://glama.ai/mcp/servers/@LucasDelgado/mcp-ts">
  <img width="380" height="200" src="https://glama.ai/mcp/servers/@LucasDelgado/mcp-ts/badge" alt="Chop TypeScript MCP server" />
</a>

Glama performs regular codebase and documentation checks to:

* Confirm that the MCP server is working as expected
* Confirm that there are no obvious security issues with dependencies of the server
* Extract server characteristics such as tools, resources, prompts, and required parameters.

This badge helps your users to quickly assess that the MCP server is safe, server capabilities, and instructions for installing the server.